### PR TITLE
Fix pause

### DIFF
--- a/Scenes/Level 1.tscn
+++ b/Scenes/Level 1.tscn
@@ -117,8 +117,6 @@ margin_right = -5.0
 margin_bottom = -35.0
 
 [node name="Pause" parent="Menus" instance=ExtResource( 6 )]
-margin_top = 70.0
-margin_bottom = 70.0
 
 [node name="Node2D" type="Node2D" parent="."]
 

--- a/Scenes/Level 1.tscn
+++ b/Scenes/Level 1.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=12 format=2]
+[gd_scene load_steps=13 format=2]
 
 [ext_resource path="res://Assets/Sprites/level-1-map.png" type="Texture" id=1]
 [ext_resource path="res://Scenes/Player.tscn" type="PackedScene" id=2]
@@ -8,6 +8,7 @@
 [ext_resource path="res://Scenes/Pause.tscn" type="PackedScene" id=6]
 [ext_resource path="res://Scenes/Ending.tscn" type="PackedScene" id=7]
 [ext_resource path="res://top-ui-theme.tres" type="Theme" id=8]
+[ext_resource path="res://Scripts/Menus.gd" type="Script" id=9]
 
 [sub_resource type="RectangleShape2D" id=1]
 extents = Vector2( 26, 303 )
@@ -93,18 +94,35 @@ __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="Pause" parent="." instance=ExtResource( 6 )]
-visible = false
+[node name="Pause_Btn" type="Button" parent="."]
+margin_left = 856.0
+margin_top = 6.0
+margin_right = 998.0
+margin_bottom = 53.0
+mouse_default_cursor_shape = 2
+theme = ExtResource( 8 )
+text = "Pause"
+__meta__ = {
+"_edit_use_anchors_": false
+}
 
-[node name="Ending" parent="." instance=ExtResource( 7 )]
+[node name="Menus" type="CanvasLayer" parent="."]
+script = ExtResource( 9 )
+
+[node name="Ending" parent="Menus" instance=ExtResource( 7 )]
 pause_mode = 2
 margin_left = -5.0
 margin_top = -35.0
 margin_right = -5.0
 margin_bottom = -35.0
 
+[node name="Pause" parent="Menus" instance=ExtResource( 6 )]
+margin_top = 70.0
+margin_bottom = 70.0
+
 [node name="Node2D" type="Node2D" parent="."]
 
 [node name="Sprite" type="Sprite" parent="Node2D"]
 
 [connection signal="body_entered" from="Door" to="." method="_on_Door_body_entered"]
+[connection signal="pressed" from="Pause_Btn" to="." method="_on_Pause_Btn_pressed"]

--- a/Scenes/Pause.tscn
+++ b/Scenes/Pause.tscn
@@ -5,6 +5,7 @@
 
 [node name="Pause" type="Control"]
 pause_mode = 2
+visible = false
 anchor_right = 1.0
 anchor_bottom = 1.0
 script = ExtResource( 2 )

--- a/Scripts/Ending.gd
+++ b/Scripts/Ending.gd
@@ -1,21 +1,11 @@
 extends Control
 
-#func _ready():
-	
-	
 func _process(_delta):
 	$Ending_Price.text = "$" + str(Global.price)
-	if (visible == true):
-		pause()
-	else:
-		resume()
-
-func pause():
-	get_tree().set_deferred("paused", true)
 
 func resume():
 	get_tree().set_deferred("paused", false)
-	
+
 func _on_R_Btn_pressed():
 	Global.price = 0
 	get_tree().change_scene("res://Scenes/Level 1.tscn")

--- a/Scripts/Level 1.gd
+++ b/Scripts/Level 1.gd
@@ -7,11 +7,16 @@ func _ready():
 # Called every frame. 'delta' is the elapsed time since the previous frame.
 func _process(delta):
 	if (Global.box_num == 0):
-		$Ending.visible = true
-#	pass
+		$Menus/Ending.visible = true
+		
 
 func _on_Door_body_entered(body):
 	if (body.get_name() == "RigidBody2D"):
 		body.queue_free()
 		Global.box_num -= 1
 		print("Boxes: " + str(Global.box_num))
+
+
+func _on_Pause_Btn_pressed():
+	$Menus/Pause.visible = true
+	

--- a/Scripts/Menus.gd
+++ b/Scripts/Menus.gd
@@ -1,0 +1,18 @@
+extends CanvasLayer
+
+var num = 0
+
+func _process(_delta):
+	if Input.is_action_just_pressed("ui_cancel") or ($Pause.visible == true) or ($Ending.visible == true):
+		if !get_tree().paused:
+			pause()
+		else:
+			resume()
+	else:
+		resume()
+#
+func pause():
+	get_tree().set_deferred("paused", true)
+	
+func resume():
+	get_tree().set_deferred("paused", false)

--- a/Scripts/Pause.gd
+++ b/Scripts/Pause.gd
@@ -1,19 +1,13 @@
 extends Control
 
-var is_paused = false
-
 func _process(_delta):
 	if Input.is_action_just_pressed("ui_cancel"):
-		if !get_tree().paused:
-			visible = true
-			pause()
-		else:
+		if (visible == true):
 			visible = false
 			resume()
-	
-func pause():
-	get_tree().set_deferred("paused", true)
-	
+		else:
+			visible = true
+
 func resume():
 	get_tree().set_deferred("paused", false)
 


### PR DESCRIPTION
This fixes the pausing issue by preventing the Pause and Ending scenes from conflicting with each other's pause script. The main pausing action is now inside the Menus script, while the Pause and Ending scripts resume the game.